### PR TITLE
如果设置自动大小，需要先设置GLoader的宽高，再计算布局，不然锚点不在左上角会出问题

### DIFF
--- a/source/fairygui/GLoader.ts
+++ b/source/fairygui/GLoader.ts
@@ -335,6 +335,8 @@ namespace fgui {
             this._content.type = cc.Sprite.Type.SIMPLE;
             this._contentSourceWidth = texture.getRect().width;
             this._contentSourceHeight = texture.getRect().height;
+            if (this._autoSize)
+                this.setSize(this._contentSourceWidth, this._contentSourceHeight);
             this.updateLayout();
         }
 


### PR DESCRIPTION
复现步骤：
加载一张外部图片，GLoader的锚点设置为左下角(只要不是左上角就行)。加载完成位置发生错误。
修复后显示正常