### PR TITLE
fix 无法正常显示透明度的bug

### DIFF
--- a/source/src/GObject.ts
+++ b/source/src/GObject.ts
@@ -75,12 +75,15 @@ export class GObject {
     public _partner: GObjectPartner;
     public _treeNode?: GTreeNode;
     public _uiTrans: UITransform;
+    public _uiOpacity: UIOpacity;
 
     private _hitTestPt?: Vec2;
 
     public constructor() {
         this._node = new Node();
         this._uiTrans = this._node.addComponent(UITransform);
+        this._uiOpacity = this.node.addComponent(UIOpacity);
+
         (<any>this._node)["$gobj"] = this;
         this._node.layer = UIConfig.defaultUILayer;
         this._uiTrans.setAnchorPoint(0, 1);
@@ -383,7 +386,7 @@ export class GObject {
         if (this._alpha != value) {
             this._alpha = value;
 
-            this._node._uiProps.opacity = this._alpha;
+            this._uiOpacity.opacity = this._alpha * 255;
 
             if (this instanceof GGroup)
                 this.handleAlphaChanged();


### PR DESCRIPTION
ccc3.x版本中，使用_uiOpacity改变透明度貌似没有效果，参考官方文档：
https://docs.cocos.com/creator/3.1/manual/zh/ui-system/components/editor/ui-opacity.html?h=%E9%80%8F%E6%98%8E%E5%BA%A6
使用UIOpacity来改变node的透明度。