### PR TITLE
fix texture not released when loader disposed.

### DIFF
--- a/source/src/GLoader.ts
+++ b/source/src/GLoader.ts
@@ -335,6 +335,7 @@ export class GLoader extends GObject {
     }
 
     protected freeExternal(texture: SpriteFrame): void {
+        assetManager.releaseAsset(texture);
     }
 
     protected onExternalLoadSuccess(texture: SpriteFrame): void {


### PR DESCRIPTION
loader在加载resources下的图片后，销毁的时候，没有释放，导致占用内存持续增加。