### PR TITLE
fix can't find bitmapfont atlas

### DIFF
--- a/source/src/GTextField.ts
+++ b/source/src/GTextField.ts
@@ -51,6 +51,7 @@ export class GTextField extends GObject {
 
     protected createRenderer() {
         this._label = this._node.addComponent(Label);
+        this._label.string = "";
         this.autoSize = AutoSizeType.Both;
     }
 


### PR DESCRIPTION
cc.Label默认字符为"label"，fgui中使用位图字体设置时，因数据异步未加载导致疯狂报错，如下图
[![X1nzes.png](https://s1.ax1x.com/2022/05/30/X1nzes.png)](https://imgtu.com/i/X1nzes)