### PR TITLE
fix:富文本设置描边后不生效bug

### DIFF
--- a/demo/assets/Script/Lib/fairygui.d.ts
+++ b/demo/assets/Script/Lib/fairygui.d.ts
@@ -1242,6 +1242,7 @@ declare namespace fgui {
     }
     class GRichTextField extends GTextField {
         _richText: cc.RichText;
+        private _outlineWidth;
         private _bold;
         private _italics;
         private _underline;
@@ -1257,6 +1258,8 @@ declare namespace fgui {
         set bold(value: boolean);
         get italic(): boolean;
         set italic(value: boolean);
+        get stroke(): number;
+        set stroke(value: number);
         protected markSizeChanged(): void;
         protected updateText(): void;
         protected updateFont(): void;

--- a/demo/assets/Script/Lib/fairygui.js
+++ b/demo/assets/Script/Lib/fairygui.js
@@ -8991,6 +8991,7 @@ window.__extends = (this && this.__extends) || (function () {
         __extends(GRichTextField, _super);
         function GRichTextField() {
             var _this = _super.call(this) || this;
+            _this._outlineWidth = 0;
             _this._node.name = "GRichTextField";
             _this._touchDisabled = false;
             _this.linkUnderline = fgui.UIConfig.linkUnderline;
@@ -9051,6 +9052,17 @@ window.__extends = (this && this.__extends) || (function () {
             enumerable: false,
             configurable: true
         });
+        Object.defineProperty(GRichTextField.prototype, "stroke", {
+            get: function () {
+                return this._outlineWidth || 0;
+            },
+            set: function (value) {
+                this._outlineWidth = value;
+                this.updateText();
+            },
+            enumerable: false,
+            configurable: true
+        });
         GRichTextField.prototype.markSizeChanged = function () {
         };
         GRichTextField.prototype.updateText = function () {
@@ -9072,6 +9084,9 @@ window.__extends = (this && this.__extends) || (function () {
             if (this._grayed)
                 c = fgui.ToolSet.toGrayed(c);
             text2 = "<color=" + c.toHEX("#rrggbb") + ">" + text2 + "</color>";
+            if (this._strokeColor && this._outlineWidth > 0) {
+                text2 = "<outline color=" + this._strokeColor.toCSS("#rrggbb") + " width=" + this._outlineWidth + ">" + text2 + "</outline>";
+            }
             if (this._autoSize == fgui.AutoSizeType.Both) {
                 if (this._richText.maxWidth != 0)
                     this._richText.maxWidth = 0;

--- a/source/bin/fairygui.d.ts
+++ b/source/bin/fairygui.d.ts
@@ -1242,6 +1242,7 @@ declare namespace fgui {
     }
     class GRichTextField extends GTextField {
         _richText: cc.RichText;
+        private _outlineWidth;
         private _bold;
         private _italics;
         private _underline;
@@ -1257,6 +1258,8 @@ declare namespace fgui {
         set bold(value: boolean);
         get italic(): boolean;
         set italic(value: boolean);
+        get stroke(): number;
+        set stroke(value: number);
         protected markSizeChanged(): void;
         protected updateText(): void;
         protected updateFont(): void;

--- a/source/bin/fairygui.js
+++ b/source/bin/fairygui.js
@@ -8991,6 +8991,7 @@ window.__extends = (this && this.__extends) || (function () {
         __extends(GRichTextField, _super);
         function GRichTextField() {
             var _this = _super.call(this) || this;
+            _this._outlineWidth = 0;
             _this._node.name = "GRichTextField";
             _this._touchDisabled = false;
             _this.linkUnderline = fgui.UIConfig.linkUnderline;
@@ -9051,6 +9052,17 @@ window.__extends = (this && this.__extends) || (function () {
             enumerable: false,
             configurable: true
         });
+        Object.defineProperty(GRichTextField.prototype, "stroke", {
+            get: function () {
+                return this._outlineWidth || 0;
+            },
+            set: function (value) {
+                this._outlineWidth = value;
+                this.updateText();
+            },
+            enumerable: false,
+            configurable: true
+        });
         GRichTextField.prototype.markSizeChanged = function () {
         };
         GRichTextField.prototype.updateText = function () {
@@ -9072,6 +9084,9 @@ window.__extends = (this && this.__extends) || (function () {
             if (this._grayed)
                 c = fgui.ToolSet.toGrayed(c);
             text2 = "<color=" + c.toHEX("#rrggbb") + ">" + text2 + "</color>";
+            if (this._strokeColor && this._outlineWidth > 0) {
+                text2 = "<outline color=" + this._strokeColor.toCSS("#rrggbb") + " width=" + this._outlineWidth + ">" + text2 + "</outline>";
+            }
             if (this._autoSize == fgui.AutoSizeType.Both) {
                 if (this._richText.maxWidth != 0)
                     this._richText.maxWidth = 0;

--- a/source/src/fairygui/GRichTextField.ts
+++ b/source/src/fairygui/GRichTextField.ts
@@ -22,7 +22,7 @@ namespace fgui {
 
     export class GRichTextField extends GTextField {
         public _richText: cc.RichText;
-
+        private _outlineWidth: number = 0;
         private _bold: boolean;
         private _italics: boolean;
         private _underline: boolean;
@@ -89,6 +89,15 @@ namespace fgui {
             }
         }
 
+        public get stroke(): number {
+            return this._outlineWidth || 0;
+        }
+
+        public set stroke(value: number) {
+            this._outlineWidth = value;
+            this.updateText();
+        }
+
         protected markSizeChanged(): void {
             //RichText貌似没有延迟重建文本，所以这里不需要
         }
@@ -116,6 +125,10 @@ namespace fgui {
             if (this._grayed)
                 c = ToolSet.toGrayed(c);
             text2 = "<color=" + c.toHEX("#rrggbb") + ">" + text2 + "</color>";
+
+            if (this._strokeColor && this._outlineWidth > 0) {
+                text2 = `<outline color=${this._strokeColor.toCSS("#rrggbb")} width=${this._outlineWidth}>${text2}</outline>`;
+            }
 
             if (this._autoSize == AutoSizeType.Both) {
                 if (this._richText.maxWidth != 0)


### PR DESCRIPTION
编辑器中设置富文本描边后不生效